### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/android-dep.yml
+++ b/.github/workflows/android-dep.yml
@@ -38,7 +38,7 @@ jobs:
           fallback: v0.0.0
       
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{github.repository}}/android-dep
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-env.yml
+++ b/.github/workflows/android-env.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fallback: v0.0.0
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{github.repository}}/android-env
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-hicn.yml
+++ b/.github/workflows/android-hicn.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fallback: v0.0.0      
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{github.repository}}/android-hicn
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -72,7 +72,7 @@ jobs:
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
       - name: Build and push aar libraries
         if: "startsWith(github.event.head_commit.message, 'bump:') && steps.run.outputs.istag == 'true'"
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_IMAGE: ghcr.io/${{github.repository}}/android-hicn:latest
           GITHUB_USERNAME: ${{ secrets.HICN_BOT }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check commits
         uses: manang/commitizen-check@v0.0.1
       - name: Verify
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_IMAGE: ghcr.io/${{github.repository}}/android-hicn:latest
           GITHUB_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore